### PR TITLE
added compile macro to prevent other app error as they may not use US…

### DIFF
--- a/product/application/usb/mdk-arm/CAF.uvprojx
+++ b/product/application/usb/mdk-arm/CAF.uvprojx
@@ -1180,7 +1180,7 @@
             <useXO>0</useXO>
             <VariousControls>
               <MiscControls>--C99 --gnu -W#177</MiscControls>
-              <Define>USE_HAL_DRIVER,STM32F401xE,USE_STM32F4XX_NUCLEO,ENABLE_SPI_FIX,BLUENRG_MS,RTC_LSE,CANNON_V2</Define>
+              <Define>USE_HAL_DRIVER,STM32F401xE,USE_STM32F4XX_NUCLEO,ENABLE_SPI_FIX,BLUENRG_MS,RTC_LSE,CANNON_V2,INCLUDE_USB_DEVICE</Define>
               <Undefine></Undefine>
               <IncludePath>..\..\..\..\system\drivers\hts221;..\..\..\..\system\drivers\lps25h;..\..\..\..\system\drivers\lps25hb;..\..\..\..\system\drivers\lsm303agr;..\..\..\..\system\drivers\lsm6ds3;..\..\..\..\system\drivers\stm32f4xx_hal_driver\inc;..\..\..\..\system\drivers\common;..\..\..\..\system\drivers\bluenrg\inc;..\..\..\..\system\drivers\bluenrg\bluenrg_ms;..\..\usb;..\..\..\..\system\bsp\nucleo;..\..\..\..\system\bsp\cannon_v2;..\..\..\..\system\juma\inc;..\..\..\..\system\cmiss\device\st\inc;..\..\..\..\system\cmiss\include;..\..\..\..\system\drivers\stm32_usb_device_library\core\inc;..\..\..\..\system\drivers\stm32_usb_device_library\class\HID\inc</IncludePath>
             </VariousControls>

--- a/system/juma/inc/cube_hal.h
+++ b/system/juma/inc/cube_hal.h
@@ -18,7 +18,9 @@
   #include "stm32f4xx_hal_conf.h"
 #endif
 
+#ifdef INCLUDE_USB_DEVICE
 #include "usbd_core.h"
+#endif
 
 void SystemClock_Config(void);
 

--- a/system/juma/src/stm32xx_it.c
+++ b/system/juma/src/stm32xx_it.c
@@ -214,6 +214,7 @@ void EXTI0_IRQHandler(void)
 }
 #endif
 
+#ifdef INCLUDE_USB_DEVICE
 extern PCD_HandleTypeDef hpcd;
 extern USBD_HandleTypeDef USBD_Device;
 
@@ -239,6 +240,7 @@ void OTG_FS_WKUP_IRQHandler(void)
   /* Clear EXTI pending Bit*/
   __HAL_USB_OTG_FS_WAKEUP_EXTI_CLEAR_FLAG();
 }
+#endif
 
 /**
  * @}


### PR DESCRIPTION
…B. To enable USB in APP, you should define 'INCLUDE_USB_DEVICE' in your project.