### PR TITLE
Add 'printf' switch macro to application

### DIFF
--- a/product/application/host/app.c
+++ b/product/application/host/app.c
@@ -1,6 +1,10 @@
 //#include "sensor_service.h"
 
 #include "app.h"
+
+#if NO_PRINTF
+#define printf(...)
+#endif
 /*start adv*/
 
 extern volatile uint8_t device_connectable;

--- a/product/application/sensor_tag_fifo/app.c
+++ b/product/application/sensor_tag_fifo/app.c
@@ -2,6 +2,10 @@
 #include "app.h"
 #include "imu_sensor_fusion.h"
 /*start adv*/
+#if NO_PRINTF
+#define printf(...)
+#endif
+
 
 float pitch, roll, yal;
 

--- a/product/application/sensor_tag_fifo/mdk-arm/CAF.uvprojx
+++ b/product/application/sensor_tag_fifo/mdk-arm/CAF.uvprojx
@@ -371,7 +371,7 @@
             <vShortWch>0</vShortWch>
             <VariousControls>
               <MiscControls>--C99 --gnu</MiscControls>
-              <Define>USE_HAL_DRIVER,STM32F401xE,USE_STM32F4XX_NUCLEO,ENABLE_SPI_FIX,BLUENRG_MS,RTC_LSE,CANNON_V1</Define>
+              <Define>USE_HAL_DRIVER,STM32F401xE,USE_STM32F4XX_NUCLEO,ENABLE_SPI_FIX,BLUENRG_MS,RTC_LSE,CANNON_V1,NO_PRINTF</Define>
               <Undefine></Undefine>
               <IncludePath>..\..\Sensor_Tag;..\..\..\..\system\bsp\cannon_v1;..\..\..\..\system\bsp\nucleo;..\..\..\..\system\drivers\lps25h;..\..\..\..\system\drivers\lps25hb;..\..\..\..\system\drivers\lsm303agr;..\..\..\..\system\drivers\lsm6ds3;..\..\..\..\system\drivers\stm32f4xx_hal_driver\inc;..\..\..\..\system\cmiss\device\st\inc;..\..\..\..\system\cmiss\include;..\..\..\..\system\juma\inc;..\..\..\..\system\drivers\common;..\..\..\..\system\drivers\bluenrg\inc;..\..\..\..\system\drivers\bluenrg\bluenrg_ms;..\..\..\..\system\drivers\hts221</IncludePath>
             </VariousControls>

--- a/system/juma/src/bluenrg_sdk_api.c
+++ b/system/juma/src/bluenrg_sdk_api.c
@@ -1,6 +1,9 @@
 
 #include "bluenrg_sdk_api.h"
 
+#if NO_PRINTF
+#define printf(...)
+#endif
 
 #define BDADDR_SIZE 6
 

--- a/system/juma/src/imu_sensor.c
+++ b/system/juma/src/imu_sensor.c
@@ -1,6 +1,9 @@
 #include "imu_sensor.h"
 #include "app.h"
 
+#if NO_PRINTF
+#define printf(...)
+#endif
 
 static sensor_selsection_t sensor_selection;
 static imu_sensor_data_sensitivity_t sensor_data_sensitivity;

--- a/system/juma/src/stm32xx_it.c
+++ b/system/juma/src/stm32xx_it.c
@@ -42,6 +42,10 @@
 #include "debug.h"
 #include "x_nucleo_iks01a1.h"
 #include "imu_sensor.h"
+
+#if NO_PRINTF
+#define printf(...)
+#endif
 /* Private variables ---------------------------------------------------------*/
 /* RTC handler declared in "main.c" file */
 extern RTC_HandleTypeDef RTCHandle;


### PR DESCRIPTION
1. add NO_PRINTF macro to switch on/off 'printf' function to the
application that use 'printf' to print information.