### PR TITLE
Add gyro auto calibration

### DIFF
--- a/system/juma/inc/imu_sensor_fusion.h
+++ b/system/juma/inc/imu_sensor_fusion.h
@@ -49,6 +49,8 @@ typedef struct _imu_sensor_fusion_1_context_t{
 typedef struct {
     uint32_t flags;
     vec3f_t gravity;
+    vec3f_t acc_last;
+    vec3f_t drift; // gyroscopic drifting rate
 } gravity_filter_context_t;
 
 void complementary_filter(float acc_raw[3], float gyr_raw[3], float mag_raw[3], float *pitch, float *roll, float *yaw);


### PR DESCRIPTION
1. Detect zero motion by checking delta of acc
2. Computer average value of gyro readings in zero motion condition
3. Substrate this value offset from raw gyro readings